### PR TITLE
fixed bug in computing gamma

### DIFF
--- a/njoy_converter.py
+++ b/njoy_converter.py
@@ -531,13 +531,15 @@ def BuildCombinedData(raw_njoy_data):
             g = entry[0]
             v = entry[1:]
             chi_delayed[G_n-g-1] += v
-        chi_delayed /= np.sum(chi_delayed,axis=0)
 
     gamma = np.zeros(J)
     if (np.sum(nu_delayed)>0 and np.sum(chi_delayed)>0):
         nu_bar_delayed = np.mean(nu_delayed)
         delayed_frac = np.sum(chi_delayed,axis=0)
         gamma = nu_bar_delayed*delayed_frac
+
+    # Normalize chi_delayed spectrum to sum to 1
+    chi_delayed /= np.sum(chi_delayed,axis=0)
 
     # ================================= Combine transfer matrices
 


### PR DESCRIPTION
To convert NJOY data to a format suitable for our uses, we had to redefine some quantities. NJOY gives delayed neutron spectra that sum to the delayed neutron fraction, not to unity as we generally use. Additionally, NJOY gives nubar delayed rather than a fission yield for a delayed neutron precursor family. In our applications, we use spectra that sum to unity and the energy independent fission yield, gamma. We define gamma as the delayed neutron fraction (sum of the spectrum for a given delayed neutron precursor group) multiplied by the average nubar delayed. In the parser, the delayed spectra was normalized before computing gamma, which led to gamma being the same for each group. This pull request fixes that issue.